### PR TITLE
Fix Kconfig and Bluetooth HCI definition

### DIFF
--- a/boards/catie/zest_core_nrf5340/Kconfig
+++ b/boards/catie/zest_core_nrf5340/Kconfig
@@ -38,7 +38,7 @@ config BOARD_ENABLE_CPUNET
 
 config DOMAIN_CPUNET_BOARD
 	string
-	default "zest_core_nrf5340_nrf5340_cpunet"
+	default "zest_core_nrf5340/nrf5340/cpunet"
 	depends on BOARD_ENABLE_CPUNET
 	help
 	  The board which will be used for CPUNET domain when creating a multi
@@ -50,7 +50,7 @@ endif #  BOARD_ZEST_CORE_NRF5340_NRF5340_CPUAPP || BOARD_ZEST_CORE_NRF5340_NRF53
 
 config DOMAIN_CPUAPP_BOARD
 	string
-	default "zest_core_nrf5340_nrf5340_cpuapp"
+	default "zest_core_nrf5340/nrf5340/cpuapp"
 	depends on BOARD_ZEST_CORE_NRF5340_NRF5340_CPUNET
 	help
 	  The board which will be used for CPUAPP domain when creating a multi

--- a/boards/catie/zest_core_nrf5340/nrf5340_cpuapp_common.dtsi
+++ b/boards/catie/zest_core_nrf5340/nrf5340_cpuapp_common.dtsi
@@ -14,7 +14,7 @@
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;
-		zephyr,bt-hci-ipc = &ipc0;
+		zephyr,bt-hci = &bt_hci_ipc0;
 		nordic,802154-spinel-ipc = &ipc0;
 		zephyr,ieee802154 = &ieee802154;
 	};


### PR DESCRIPTION
Some change has been done when updating to hardware model v2 that I forget to include in my previous port