### PR TITLE
Removed unsupported include

### DIFF
--- a/boards/catie/zest_core_nrf5340/board.cmake
+++ b/boards/catie/zest_core_nrf5340/board.cmake
@@ -16,6 +16,4 @@ if(CONFIG_BOARD_ZEST_CORE_NRF5340_NRF5340_CPUNET)
 board_runner_args(jlink "--device=nrf5340_xxaa_net" "--speed=4000")
 endif()
 
-include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
`nrfjprog` and `nrfutil` are not supported by 6tron.
They are then removed from board.cmake to fix compile errors.