### PR TITLE
15 conflict between uart1 and i2c1 peripherals

### DIFF
--- a/boards/catie/zest_core_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/catie/zest_core_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
@@ -4,14 +4,14 @@
  */
 
 &pinctrl {
-	i2c1_default: i2c1_default {
+	i2c2_default: i2c2_default {
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
 					<NRF_PSEL(TWIM_SCL, 1, 3)>;
 		};
 	};
 
-	i2c1_sleep: i2c1_sleep {
+	i2c2_sleep: i2c2_sleep {
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
 					<NRF_PSEL(TWIM_SCL, 1, 3)>;

--- a/boards/catie/zest_core_nrf5340/nrf5340_cpuapp_common.dtsi
+++ b/boards/catie/zest_core_nrf5340/nrf5340_cpuapp_common.dtsi
@@ -80,11 +80,11 @@
 	status = "okay";
 };
 
-&i2c1 {
+&i2c2 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	pinctrl-0 = <&i2c1_default>;
-	pinctrl-1 = <&i2c1_sleep>;
+	pinctrl-0 = <&i2c2_default>;
+	pinctrl-1 = <&i2c2_sleep>;
 	pinctrl-names = "default", "sleep";
 };
 

--- a/boards/catie/zest_core_nrf5340/sixtron_connector.dtsi
+++ b/boards/catie/zest_core_nrf5340/sixtron_connector.dtsi
@@ -59,7 +59,7 @@
     };
 };
 
-sixtron_connector_1_i2c: &i2c1 {};
+sixtron_connector_1_i2c: &i2c2 {};
 sixtron_connector_1_uart: &uart1 {};
 sixtron_connector_1_spi: &spi4 {};
 


### PR DESCRIPTION
Changed I2C1 for I2C2 because for impossible usage of I2C1 and UART1 together.
Changed every i2c1 definition for i2c2 and kept pin IO previously defined for I2C1.

> [!Note]
> Validated on [Maxim MAX17201 driver](https://github.com/catie-aq/zephyr_maxim-max17201)