### PR TITLE
fix(kconfig): deprecated BOARD_ENABLE_DCDC_* since zephyr 4.0

### DIFF
--- a/boards/catie/zest_core_nrf5340/Kconfig
+++ b/boards/catie/zest_core_nrf5340/Kconfig
@@ -5,21 +5,6 @@
 
 if BOARD_ZEST_CORE_NRF5340_NRF5340_CPUAPP || BOARD_ZEST_CORE_NRF5340_NRF5340_CPUAPP_NS
 
-config BOARD_ENABLE_DCDC_APP
-	bool "Application MCU DCDC converter"
-	select SOC_DCDC_NRF53X_APP
-	default y
-
-config BOARD_ENABLE_DCDC_NET
-	bool "Network MCU DCDC converter"
-	select SOC_DCDC_NRF53X_NET
-	default y
-
-config BOARD_ENABLE_DCDC_HV
-	bool "High Voltage DCDC converter"
-	select SOC_DCDC_NRF53X_HV
-	default y
-
 config BOARD_ENABLE_CPUNET
 	bool "NRF53 Network MCU"
 	select SOC_NRF_GPIO_FORWARDER_FOR_NRF5340 if \


### PR DESCRIPTION
# Description:
Deprecated symbol during the build.

```
warning: Deprecated symbol SOC_DCDC_NRF53X_APP is enabled.
warning: Deprecated symbol SOC_DCDC_NRF53X_NET is enabled.
warning: Deprecated symbol SOC_DCDC_NRF53X_HV is enabled.
```

Defined on `6tron-workspace/6tron/boards/zest_core_nrf5340/boards/catie/zest_core_nrf5340/Kconfig` file. 

`6tron-workspace/zephyr/doc/releases/migration-guide-4.0.rst` , line 290 show them as deprecated
